### PR TITLE
[CraftToStack] Add compatibility for EAQS and Epic Loot.

### DIFF
--- a/CraftToStack/CraftToStack.cs
+++ b/CraftToStack/CraftToStack.cs
@@ -34,12 +34,12 @@ namespace RagnarsRokare.CraftToStack
             harmony.PatchAll();
             NexusID = Config.Bind<int>("General", "NexusID", 982, "Nexus mod ID for updates");
 
-            if (Chainloader.PluginInfos.ContainsKey("randyknapp.mods.equipmentandquickslots"))
+            if (Chainloader.PluginInfos.ContainsKey(EAQSPluginId))
             {
                 CompatPatchEAQS();
             }
 
-            if (Chainloader.PluginInfos.ContainsKey("randyknapp.mods.epicloot"))
+            if (Chainloader.PluginInfos.ContainsKey(EpicLootPluginId))
             {
                 CompatPatchEpicLoot();
             }


### PR DESCRIPTION
Hi, just some additions to get things working with the above addons. This has no patches for Extended Item Data Framework as that is now compatible as-is in its latest update (1.0.1).